### PR TITLE
Make Chatter work correctly with or without URI mapping

### DIFF
--- a/ViewModels/ChatGroupPage.json.cs
+++ b/ViewModels/ChatGroupPage.json.cs
@@ -95,7 +95,7 @@ namespace Chatter
                 UserName = UserName,
                 User = user
             };
-            ChatMessageDraft = Self.GET<Json>("/chatter/partials/chatmessages/" + draft.Key);
+            ChatMessageDraft = Self.GET<Json>("/chatter/partials/chatmessages-draft/" + draft.Key);
         }
 
         public void Refresh(string key)


### PR DESCRIPTION
Turns out that URI mapping was (almost) magically fixing a wrong `Self.GET`. When we want the draft view of a text chat message, we should `Self.GET` that explicitly.

Before this fix, Chatter was requesting a published view of a text chat message, which got redirected by the conditional URI mapping ( https://github.com/StarcounterApps/Chatter/blob/b106e64d3714e22e9b5b59b25599ae03b402d316/Api/MainHandlers.cs#L221-L230) to the draft view of a text chat message.

This PR fixes the problem. As a proof, one can comment `RegisterMap()` in Chatter and the app will still work in any mode: 

- Chatter
- Chatter + Images
- Website + Chatter + Images

@un-tone could you pls review?